### PR TITLE
Add Stored Procedure Command Timeout

### DIFF
--- a/Granfeldt.SQL.MA/Configuration.cs
+++ b/Granfeldt.SQL.MA/Configuration.cs
@@ -65,8 +65,9 @@ namespace Granfeldt
 		public static string ExportObjectCommandBefore = "";
 		public static string ExportObjectCommandAfter = "";
         public static string DateFormat = "yyyy-MM-ddTHH:mm:ss.fff";
+		public static string CommandTimeout = "30";
 
-        public static ObjectClassType ObjectClassType = ObjectClassType.Column;
+		public static ObjectClassType ObjectClassType = ObjectClassType.Column;
 		public static DeltaColumnType DeltaColumnType = DeltaColumnType.Rowversion;
 
 		public static SchemaConfiguration Schema = new SchemaConfiguration();
@@ -169,8 +170,10 @@ namespace Granfeldt
 			public const string ExportCommandAfter = "Run after export";
 			public const string ExportObjectCommandBefore = "Run before export object";
 			public const string ExportObjectCommandAfter = "Run after export object";
+			public const string CommandTimeout = "Stored Procedure timeout seconds (default 30)";
 
-            public const string DateFormat = "Date format";
+
+			public const string DateFormat = "Date format";
         }
 		public static IEnumerable<string> ReservedColumnNames
 		{

--- a/Granfeldt.SQL.MA/Configuration.cs
+++ b/Granfeldt.SQL.MA/Configuration.cs
@@ -170,7 +170,8 @@ namespace Granfeldt
 			public const string ExportCommandAfter = "Run after export";
 			public const string ExportObjectCommandBefore = "Run before export object";
 			public const string ExportObjectCommandAfter = "Run after export object";
-			public const string CommandTimeout = "Stored Procedure timeout seconds (default 30)";
+			//Define the Stored Procedure command timeout text
+			public const string CommandTimeout = "Stored Procedure timeout in seconds (min=30, max=99999, default=30)";
 
 
 			public const string DateFormat = "Date format";

--- a/Granfeldt.SQL.MA/MA/Sql.MA.ExportDetached.cs
+++ b/Granfeldt.SQL.MA/MA/Sql.MA.ExportDetached.cs
@@ -47,7 +47,7 @@ namespace Granfeldt
 				{
 					List<SqlParameter> parameters = new List<SqlParameter>();
 					parameters.Add(new SqlParameter("exporttype", ExportType.ToString()));
-					methods.RunStoredProcedure(Configuration.ExportCommandBefore, parameters);
+					methods.RunStoredProcedure(Configuration.ExportCommandBefore, parameters, Convert.ToInt32(Configuration.CommandTimeout));
 				}
 			}
 			catch (Exception ex)
@@ -91,7 +91,7 @@ namespace Granfeldt
 						List<SqlParameter> parameters = new List<SqlParameter>();
 						parameters.Add(new SqlParameter("anchor", anchor));
 						parameters.Add(new SqlParameter("action", exportChange.ObjectModificationType.ToString()));
-						methods.RunStoredProcedure(Configuration.ExportObjectCommandBefore, parameters);
+						methods.RunStoredProcedure(Configuration.ExportObjectCommandBefore, parameters, Convert.ToInt32(Configuration.CommandTimeout));
 					}
 
 					Tracer.TraceInformation("export-object {0}, cs-id: {1}, anchor: {2}, dn: {3} [{4}]", objectClass, exportChange.Identifier, anchor, exportChange.DN, exportChange.ObjectModificationType);
@@ -171,7 +171,7 @@ namespace Granfeldt
 							List<SqlParameter> parameters = new List<SqlParameter>();
 							parameters.Add(new SqlParameter("anchor", anchor));
 							parameters.Add(new SqlParameter("action", exportChange.ObjectModificationType.ToString()));
-							methods.RunStoredProcedure(Configuration.ExportObjectCommandAfter, parameters);
+							methods.RunStoredProcedure(Configuration.ExportObjectCommandAfter, parameters, Convert.ToInt32(Configuration.CommandTimeout));
 						}
 					}
 					catch (Exception exportEx)
@@ -202,7 +202,7 @@ namespace Granfeldt
 				{
 					List<SqlParameter> parameters = new List<SqlParameter>();
 					parameters.Add(new SqlParameter("exporttype", ExportType.ToString()));
-					methods.RunStoredProcedure(Configuration.ExportCommandAfter, parameters);
+					methods.RunStoredProcedure(Configuration.ExportCommandAfter, parameters, Convert.ToInt32(Configuration.CommandTimeout));
 				}
 				methods.CloseConnection();
 			}

--- a/Granfeldt.SQL.MA/MA/Sql.MA.ImportDetached.cs
+++ b/Granfeldt.SQL.MA/MA/Sql.MA.ImportDetached.cs
@@ -306,7 +306,7 @@ namespace Granfeldt
                     List<SqlParameter> parameters = new List<SqlParameter>();
                     parameters.Add(new SqlParameter("importtype", ImportType.ToString()));
                     parameters.Add(new SqlParameter("customdata", CustomData));
-                    methods.RunStoredProcedure(Configuration.ImportCommandBefore, parameters);
+                    methods.RunStoredProcedure(Configuration.ImportCommandBefore, parameters, Convert.ToInt32(Configuration.CommandTimeout));
                     parameters.Clear();
                     parameters = null;
                 }
@@ -409,7 +409,7 @@ namespace Granfeldt
                     List<SqlParameter> parameters = new List<SqlParameter>();
                     parameters.Add(new SqlParameter("importtype", ImportType.ToString()));
                     parameters.Add(new SqlParameter("customdata", CustomData));
-                    methods.RunStoredProcedure(Configuration.ImportCommandAfter, parameters);
+                    methods.RunStoredProcedure(Configuration.ImportCommandAfter, parameters, Convert.ToInt32(Configuration.CommandTimeout));
                     parameters.Clear();
                     parameters = null;
                 }

--- a/Granfeldt.SQL.MA/MA/Sql.MA.Parameters.cs
+++ b/Granfeldt.SQL.MA/MA/Sql.MA.Parameters.cs
@@ -96,7 +96,9 @@ namespace Granfeldt
                         configParametersDefinitions.Add(ConfigParameterDefinition.CreateStringParameter(Configuration.Parameters.ExportObjectCommandBefore, Configuration.ExportObjectCommandBefore));
                         configParametersDefinitions.Add(ConfigParameterDefinition.CreateStringParameter(Configuration.Parameters.ExportObjectCommandAfter, Configuration.ExportObjectCommandAfter));
                         configParametersDefinitions.Add(ConfigParameterDefinition.CreateDividerParameter());
-                        configParametersDefinitions.Add(ConfigParameterDefinition.CreateStringParameter(Configuration.Parameters.CommandTimeout, Configuration.CommandTimeout, Configuration.CommandTimeout));
+                        //Regex validating minimal 30 and max 99999 seconds: "^([3-9][0-9]|[0-9][0-9][0-9]|[0-9][0-9][0-9][0-9]|[0-9][0-9][0-9][0-9][0-9])$"
+                        configParametersDefinitions.Add(ConfigParameterDefinition.CreateStringParameter(Configuration.Parameters.CommandTimeout, "^([3-9][0-9]|[0-9][0-9][0-9]|[0-9][0-9][0-9][0-9]|[0-9][0-9][0-9][0-9][0-9])$", Configuration.CommandTimeout));
+
 
 
                         break;

--- a/Granfeldt.SQL.MA/MA/Sql.MA.Parameters.cs
+++ b/Granfeldt.SQL.MA/MA/Sql.MA.Parameters.cs
@@ -95,6 +95,9 @@ namespace Granfeldt
                         configParametersDefinitions.Add(ConfigParameterDefinition.CreateStringParameter(Configuration.Parameters.ExportCommandAfter, Configuration.ExportCommandAfter));
                         configParametersDefinitions.Add(ConfigParameterDefinition.CreateStringParameter(Configuration.Parameters.ExportObjectCommandBefore, Configuration.ExportObjectCommandBefore));
                         configParametersDefinitions.Add(ConfigParameterDefinition.CreateStringParameter(Configuration.Parameters.ExportObjectCommandAfter, Configuration.ExportObjectCommandAfter));
+                        configParametersDefinitions.Add(ConfigParameterDefinition.CreateDividerParameter());
+                        configParametersDefinitions.Add(ConfigParameterDefinition.CreateStringParameter(Configuration.Parameters.CommandTimeout, Configuration.CommandTimeout, Configuration.CommandTimeout));
+
 
                         break;
                     case ConfigParameterPage.Partition:
@@ -189,6 +192,7 @@ namespace Granfeldt
                         if (cp.Name.Equals(Configuration.Parameters.ExportCommandAfter)) Configuration.ExportCommandAfter = configParameters[cp.Name].Value;
                         if (cp.Name.Equals(Configuration.Parameters.ExportObjectCommandBefore)) Configuration.ExportObjectCommandBefore = configParameters[cp.Name].Value;
                         if (cp.Name.Equals(Configuration.Parameters.ExportObjectCommandAfter)) Configuration.ExportObjectCommandAfter = configParameters[cp.Name].Value;
+                        if (cp.Name.Equals(Configuration.Parameters.CommandTimeout)) Configuration.CommandTimeout = configParameters[cp.Name].Value;
 
                         if (cp.Name.Equals(Configuration.Parameters.DateFormat)) Configuration.DateFormat = configParameters[cp.Name].Value;
 

--- a/Granfeldt.SQL.MA/Properties/AssemblyInfo.cs
+++ b/Granfeldt.SQL.MA/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.2020.1012")]
+[assembly: AssemblyFileVersion("1.0.2020.1013")]

--- a/Granfeldt.SQL.MA/SqlMethods/SqlMethods.StoredProcedures.cs
+++ b/Granfeldt.SQL.MA/SqlMethods/SqlMethods.StoredProcedures.cs
@@ -56,5 +56,40 @@ namespace Granfeldt
 				Tracer.Exit("runstoredprocedure");
 			}
 		}
+
+		public void RunStoredProcedure(string query, IEnumerable<SqlParameter> parameters, int CommandTimeout)
+		{
+			Tracer.Enter("runstoredprocedure");
+			try
+			{
+				using (SqlCommand cmd = new SqlCommand(query, con))
+				{
+					cmd.CommandType = CommandType.StoredProcedure;
+					
+					if(CommandTimeout > 30)
+					{
+						Tracer.Enter("runstoredprocedure: CommandTimeout = " + CommandTimeout);
+						cmd.CommandTimeout = CommandTimeout;
+					}
+					
+					cmd.CommandTimeout = CommandTimeout;
+					foreach (SqlParameter param in parameters)
+					{
+						Tracer.TraceInformation("add-parameter name: {0}, value: '{1}'", param.ParameterName, param.SqlValue);
+						cmd.Parameters.Add(param);
+					}
+					Tracer.TraceInformation("run-storedprocedure {0}", query);
+					Tracer.TraceInformation("rows-affected {0:n0}", cmd.ExecuteNonQuery());
+				}
+			}
+			catch (Exception ex)
+			{
+				Tracer.TraceError("runstoredprocedure", ex);
+			}
+			finally
+			{
+				Tracer.Exit("runstoredprocedure");
+			}
+		}
 	}
 }

--- a/Granfeldt.SQL.MA/SqlMethods/SqlMethods.StoredProcedures.cs
+++ b/Granfeldt.SQL.MA/SqlMethods/SqlMethods.StoredProcedures.cs
@@ -65,20 +65,16 @@ namespace Granfeldt
 				using (SqlCommand cmd = new SqlCommand(query, con))
 				{
 					cmd.CommandType = CommandType.StoredProcedure;
-					
-					if(CommandTimeout > 30)
-					{
-						Tracer.Enter("runstoredprocedure: CommandTimeout = " + CommandTimeout);
-						cmd.CommandTimeout = CommandTimeout;
-					}
-					
+
+                    //Set the command timeout in seconds (Source: https://docs.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlcommand.commandtimeout?view=netframework-4.5.2
 					cmd.CommandTimeout = CommandTimeout;
+
 					foreach (SqlParameter param in parameters)
 					{
 						Tracer.TraceInformation("add-parameter name: {0}, value: '{1}'", param.ParameterName, param.SqlValue);
 						cmd.Parameters.Add(param);
 					}
-					Tracer.TraceInformation("run-storedprocedure {0}", query);
+					Tracer.TraceInformation("run-storedprocedure {0} with command timeout: {1}", query, CommandTimeout);
 					Tracer.TraceInformation("rows-affected {0:n0}", cmd.ExecuteNonQuery());
 				}
 			}


### PR DESCRIPTION
Add configurable stored procedure command timeout from 30 to 99999 seconds using .Net [SqlCommand.CommandTimeout Property](https://docs.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlcommand.commandtimeout?view=netframework-4.5.2).