### PR TITLE
Added a try catch to the resolving of group names

### DIFF
--- a/Granfeldt.SQL.MA/SqlMethods/SqlMethods.Impersonation.cs
+++ b/Granfeldt.SQL.MA/SqlMethods/SqlMethods.Impersonation.cs
@@ -202,8 +202,20 @@ namespace Granfeldt
                     {
                         foreach (IdentityReference group in currentIdentity.Groups)
                         {
-                            NTAccount account = group.Translate(typeof(NTAccount)) as NTAccount;
-                            Tracer.TraceInformation("group-membership {0}", account.Value);
+                            try
+                            {
+                                NTAccount account = group.Translate(typeof(NTAccount)) as NTAccount;
+                                Tracer.TraceInformation("group-membership {0}", account.Value);
+                            }
+                            catch (Exception ex)
+                            {
+                                /*
+								 * If the SID cannot be resolved, log the SID, but don't throw the exception.
+								 * Throwing the exception kills the run profile, where the membership might be totally
+								 * irrelevant. We do log the SID for diagnostic purpose.
+								 */
+                                Tracer.TraceError($"error-resolving-current-group-name: {group.Value}", ex);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Added a try catch to the resolving of group names. (Same fix as in pull request https://github.com/sorengranfeldt/psma/pull/19 for the PSMA)

Related issue: https://github.com/sorengranfeldt/sqlma/issues/20