### PR TITLE
Escape anchors to support anchors that contain a single quote

### DIFF
--- a/Granfeldt.SQL.MA/SqlMethods/SqlMethods.Import.cs
+++ b/Granfeldt.SQL.MA/SqlMethods/SqlMethods.Import.cs
@@ -31,7 +31,7 @@ namespace Granfeldt
                 for (int i = 0; i < anchors.Count; i++)
                 {
                     if (i > 0) anchorList.Append(",");
-                    anchorList.AppendFormat("'{0}'", anchors[i]);
+                    anchorList.AppendFormat("'{0}'", $"{anchors[i]}".Replace("'","''"));
                 }
 
                 StringBuilder query = new StringBuilder();


### PR DESCRIPTION
Anchors that contain a single quote result in the following error: "System.Data.SqlClient.SqlException (0x80131904): Incorrect syntax near '_Value_'.

This pull request escapes single quotes in the anchor list during import. This should resolve issue #4.